### PR TITLE
Install clippy in Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,6 @@ RUN    /root/.cargo/bin/cargo install cargo-outdated
 RUN    /root/.cargo/bin/cargo install cargo-graph
 RUN    /root/.cargo/bin/cargo install cargo-modules
 RUN    /root/.cargo/bin/cargo install cargo-count
+
+RUN    /root/.cargo/bin/rustup install nightly
+RUN    /root/.cargo/bin/rustup run nightly cargo install clippy

--- a/README.md
+++ b/README.md
@@ -7,6 +7,50 @@ CSearch
 Making Code Search Great Again.
 
 
+Developing CSearch
+------------------
+Install the [Rust] development tools on your system with [rustup] if they are
+not already available. Then build and test the project using:
+
+    cargo test
+
+[Rust]: https://www.rust-lang.org
+[rustup]: https://www.rustup.rs
+
+
+Docker
+------
+A [Docker] container definition is provided with installations of the tools
+used to develop CSearch. To use the container, first install Docker if not
+already available and start a Docker terminal. Then create the container by
+running the following build at the top level of the repository source tree:
+
+    docker build --rm=true -t csearch .
+
+[Docker]: http://docker.io
+
+Once built, an interactive shell can be run in the container using:
+
+    docker run -it -v "$(pwd):/csearch" --workdir=/csearch csearch /bin/bash
+
+The current working directory from the host machine is available as the current
+directory in the container so it is possible to build and test the library as
+described earlier.
+
+    cargo test
+
+
+Running Clippy Lints
+--------------------
+[Clippy] is a Rust linter. Currently it has to be run manually since CSearch
+targets Rust stable and Clippy requires Rust nightly. Switching versions is
+easy with `rustup` - use the following to lint the repository:
+
+    rustup run nightly cargo clippy
+
+[Clippy]: https://github.com/Manishearth/rust-clippy
+
+
 License
 -------
 


### PR DESCRIPTION
This works towards fixing #6 but doesn't include the CI.

Needs work in .travis.yml to figure out if it is possible to customize the build by Rust version since we only want to run the linter if in nightly. Note also that clippy is occasionally broken on nightly but this won't break the build since nightly is allowed to fail.
