### PR TITLE
Add Makefile as alternative to copying Docker cmds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: build
+
+docker: Dockerfile
+	docker build --rm=true -t grrr .
+
+shell:
+	docker run -it -v "$(CURDIR):/grrr" --workdir=/grrr grrr /bin/bash
+
+
+.PHONY: docker shell

--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ used to develop Golden Retriever. To use the container, first install Docker if
 not already available and start a Docker terminal. Then create the container by
 running the following build at the top level of the repository source tree:
 
+    make docker
+
+You can also manually invoke the docker command if you want to customize it:
+
     docker build --rm=true -t grrr .
 
 [Docker]: http://docker.io
 
 Once built, an interactive shell can be run in the container using:
+
+    make shell
+
+Again, if you want to customize the command invoked, use this as your base:
 
     docker run -it -v "$(pwd):/grrr" --workdir=/grrr grrr /bin/bash
 


### PR DESCRIPTION
Let me know what you think of this. I'd like to have something that doesn't make me copy commands from the readme. Could also be a shell script or a couple of them.
